### PR TITLE
Better server delta time

### DIFF
--- a/src/gameController.ts
+++ b/src/gameController.ts
@@ -75,6 +75,11 @@ export const setGameState = (newState: GAME_STATE) => {
   emitGameState(gameState);
 };
 
+const getProcessMs = () => {
+  const hrTime = process.hrtime()
+  return (hrTime[0] * 1000000000 + hrTime[1]) / 1000000
+}
+
 const tick = (delta: number) => {
   handleGamePhysics(players, delta);
   handlePortalLogic(players);
@@ -92,9 +97,9 @@ const tick = (delta: number) => {
 
 loadMap("default");
 
-let lastUpdate = Date.now();
+let lastUpdate = getProcessMs()
 setInterval(() => {
-  const now = Date.now();
+  const now = getProcessMs();
   tick(now - lastUpdate);
   lastUpdate = now;
 }, 1000 / TICK_RATE);

--- a/src/gameController.ts
+++ b/src/gameController.ts
@@ -76,8 +76,8 @@ export const setGameState = (newState: GAME_STATE) => {
 };
 
 const getProcessMs = () => {
-  const hrTime = process.hrtime()
-  return (hrTime[0] * 1000000000 + hrTime[1]) / 1000000
+  const hrTime = process.hrtime();
+  return (hrTime[0] * 1e9 + hrTime[1]) / 1e6;
 }
 
 const tick = (delta: number) => {
@@ -97,7 +97,7 @@ const tick = (delta: number) => {
 
 loadMap("default");
 
-let lastUpdate = getProcessMs()
+let lastUpdate = getProcessMs();
 setInterval(() => {
   const now = getProcessMs();
   tick(now - lastUpdate);


### PR DESCRIPTION
Using process.hourtime() is far more accurate than Date.now() for games.
It makes delta a floating point instead of an integer (so more accurate movement if server tick interval is inconsistent)