### PR TITLE
Optimized client players list

### DIFF
--- a/client/js/minimap.ts
+++ b/client/js/minimap.ts
@@ -101,9 +101,7 @@ export function drawMinimap(ctx: CanvasRenderingContext2D) {
     MINIMAP_IMAGE.height
   )
 
-  const players = getPlayers();
-  for (let i = 0; i < players.length; i++) {
-    const player = players[i];
+  for (const player of getPlayers()) {
     ctx.fillStyle = player.isZombie ? "#00FF00" : "#FFFFFF";
 
     if (player.y < 2600 && player.x > -110 && player.x < 3900) ctx.fillRect(

--- a/client/js/minimap.ts
+++ b/client/js/minimap.ts
@@ -102,7 +102,8 @@ export function drawMinimap(ctx: CanvasRenderingContext2D) {
   )
 
   const players = getPlayers();
-  for (let player of players) {
+  for (let i = 0; i < players.length; i++) {
+    const player = players[i];
     ctx.fillStyle = player.isZombie ? "#00FF00" : "#FFFFFF";
 
     if (player.y < 2600 && player.x > -110 && player.x < 3900) ctx.fillRect(

--- a/client/js/player.ts
+++ b/client/js/player.ts
@@ -107,10 +107,7 @@ function drawArrows(player: TPlayer, camera: Camera) {
 }
 
 export function drawPlayers(ctx: CanvasRenderingContext2D, camera: Camera) {
-  const playerList = players.getList();
-  for (let i = 0; i < playerList.length; i++) {
-
-    const player = playerList[i];
+  for (const player of players.getList()) {
     const drawPlayer = drawPlayerFactory(ctx, player, camera);
 
     if (DRAW_HITBOX) {
@@ -152,9 +149,7 @@ export function drawPlayers(ctx: CanvasRenderingContext2D, camera: Camera) {
 }
 
 export function updatePlayers(delta: number) {
-  const playerList = players.getList()
-  for (let i = 0; i < playerList.length; i++) {
-    const player = playerList[i]
+  for (const player of players.getList()) {
     const target = interpolations[player.id];
     if (!target) continue;
     const t = Math.min(1, target.t / (1000 / TICK_RATE));

--- a/src/EDictionary.ts
+++ b/src/EDictionary.ts
@@ -1,0 +1,49 @@
+// rename this file whatever u like
+export class EDictionary<T_ID,T_OBJECT> {
+    private list: T_OBJECT[];
+    private map: Map<T_ID, number>;
+    constructor() {
+        this.list = [];
+        this.map = new Map();
+    }
+    set(id: T_ID, entity: T_OBJECT) {
+        if (this.has(id)) throw new Error(`The id ${id} already exists on the EDictionary`);
+        const list_index = this.list.length;
+        this.map.set(id, list_index);
+        this.list.push(entity);
+    }
+    delete(id: T_ID) {
+        const list_index = this.map.get(id);
+        if (list_index == undefined) return false;
+        if (list_index === this.list.length) {
+            this.list.pop();
+        } else {
+            const entity = this.list[list_index];
+            const temp = this.list[this.list.length - 1];
+            this.list[this.list.length - 1] = entity;
+            this.list[list_index] = temp;
+            this.list.pop();
+        }
+        this.map.delete(id);
+        return true;
+    }
+    get(id: T_ID) {
+        const idx = this.map.get(id) as number;
+        return this.list[idx];
+    }
+    has(id: T_ID) {
+        return this.map.has(id);
+    }
+    clear() {
+        this.list = [];
+        this.map = new Map();
+    }
+    getList() {
+        return this.list;
+    }
+    forEach(cb: Function) {
+        for (let i = 0; i < this.list.length; i++) {
+            cb(this.list[i], i, this.list);
+        }
+    }
+}


### PR DESCRIPTION
I created a common EDictionary which works basically the same as a map, but you get fast array iteration on the players.
get: O(1)
set: O(1)
delete: O(1)
clear: O(1)
has: O(1)
Now to get a player by id u just say players.get(player.id) instead of using the find method.
u can say:
.getList()
to get an array of all players (there's no converting to array, so its fast)